### PR TITLE
add interfaces of annotation signing and verification for better error handling

### DIFF
--- a/pkg/cosign/sign.go
+++ b/pkg/cosign/sign.go
@@ -1,11 +1,11 @@
 //
-// Copyright 2020 IBM Corporation
+// Copyright 2021 The Sigstore Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1,11 +1,11 @@
 //
-// Copyright 2020 IBM Corporation
+// Copyright 2021 The Sigstore Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/k8smanifest/sign.go
+++ b/pkg/k8smanifest/sign.go
@@ -39,7 +39,7 @@ const (
 	SignatureAnnotationKey   = "cosign.sigstore.dev/signature"
 	CertificateAnnotationKey = "cosign.sigstore.dev/certificate"
 	MessageAnnotationKey     = "cosign.sigstore.dev/message"
-	BundleAnnotationKey      = "cosign.sigstore.dev/bundle" // bundle is not supported in cosign.SignBlob() so far
+	BundleAnnotationKey      = "cosign.sigstore.dev/bundle" // bundle is not supported in cosign.SignBlob() yet
 )
 
 func Sign(inputDir string, so *SignOption) ([]byte, error) {
@@ -67,8 +67,7 @@ func NewSigner(imageRef, keyPath string) Signer {
 		prikeyPath = &keyPath
 	}
 	if imageRef == "" {
-		// TODO: support annotation signature
-		return nil
+		return &AnnotationSigner{}
 	} else {
 		return &ImageSigner{imageRef: imageRef, prikeyPath: prikeyPath}
 	}
@@ -108,6 +107,14 @@ func (s *ImageSigner) Sign(inputDir, output string) ([]byte, error) {
 		}
 	}
 	return signedBytes, nil
+}
+
+type AnnotationSigner struct {
+}
+
+func (s *AnnotationSigner) Sign(inputDir, output string) ([]byte, error) {
+	// TODO: support annotation signature
+	return nil, errors.New("annotation-embedded signature is not supported yet")
 }
 
 func uploadFileToRegistry(inputData []byte, imageRef string) error {

--- a/pkg/k8smanifest/verify.go
+++ b/pkg/k8smanifest/verify.go
@@ -48,8 +48,7 @@ func NewSignatureVerifier(objYAMLBytes []byte, imageRef string, pubkeyPath *stri
 		}
 	}
 	if imageRef == "" {
-		// TODO: support annotation signature
-		return nil
+		return &AnnotationSignatureVerifier{}
 	} else {
 		return &ImageSignatureVerifier{imageRef: imageRef}
 	}
@@ -70,6 +69,14 @@ func (v *ImageSignatureVerifier) Verify() (bool, string, error) {
 	return k8smnfcosign.VerifyImage(imageRef, v.pubkeyPath)
 }
 
+type AnnotationSignatureVerifier struct {
+}
+
+func (v *AnnotationSignatureVerifier) Verify() (bool, string, error) {
+	// TODO: support annotation signature
+	return false, "", errors.New("annotation-embedded signature is not supported yet")
+}
+
 // This is an interface for fetching YAML manifest
 // a function Fetch() fetches a YAML manifest which matches the input object's kind, name and so on
 type ManifestFetcher interface {
@@ -78,8 +85,7 @@ type ManifestFetcher interface {
 
 func NewManifestFetcher(imageRef string) ManifestFetcher {
 	if imageRef == "" {
-		// TODO: support annotation signature
-		return nil
+		return &AnnotationManifestFetcher{}
 	} else {
 		return &ImageManifestFetcher{imageRef: imageRef}
 	}
@@ -127,6 +133,14 @@ func (f *ImageManifestFetcher) getConcatYAMLFromImageRef(imageRef string) ([]byt
 		return nil, err
 	}
 	return concatYAMLbytes, nil
+}
+
+type AnnotationManifestFetcher struct {
+}
+
+func (f *AnnotationManifestFetcher) Fetch(objYAMLBytes []byte) ([]byte, error) {
+	// TODO: support annotation signature
+	return nil, errors.New("annotation-embedded signature is not supported yet")
 }
 
 type VerifyResult struct {

--- a/pkg/k8smanifest/verify_manifest.go
+++ b/pkg/k8smanifest/verify_manifest.go
@@ -1,11 +1,11 @@
 //
-// Copyright 2020 IBM Corporation
+// Copyright 2021 The Sigstore Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
- add interfaces of annotation signing & verification so that it could return proper error message
- use sigstore license in newly added go files 